### PR TITLE
Fix empty dict check

### DIFF
--- a/src/data2latex/iter_protocols.py
+++ b/src/data2latex/iter_protocols.py
@@ -13,6 +13,15 @@ from typing import (
 )
 
 
+def replace_multiple(
+    source: str, to_be_replaced: List[str], replace_with: str = ""
+) -> str:
+    result: str = source
+    for substring in to_be_replaced:
+        result = result.replace(substring, replace_with)
+    return result
+
+
 def dict2str(
     data: Any | Dict[Any, Any],
     enclose: bool = False,
@@ -31,7 +40,7 @@ def dict2str(
                     parts.append(key)
             else:
                 new_value: str = dict2str(value, enclose=True, level=level + 1)
-                if new_value == "{}":
+                if replace_multiple(new_value, ["\t", "\n", " ", "%"]) == "{}":
                     continue
                 parts.append(f"{key}={new_value}")
         tabs = "\t" * level

--- a/src/data2latex/plot.py
+++ b/src/data2latex/plot.py
@@ -389,7 +389,7 @@ def plot(
     mark_stroke_opacity: Union[float, List[float]] = 0.0,
 ) -> None:
     """
-    Generate LaTeX scatter or line plot from input data. The plot is created with ``pgfplots`` package (``tikzpicture`` + ``axis`` environment). Data can be in the form of a list or an array of numbers for single single line. For plotting more data sets, input data should be in the form of list of lists as shown below:
+    Generate LaTeX scatter or line plot from input data. The plot is created with ``pgfplots`` package (``tikzpicture`` + ``axis`` environment). Data can be in the form of a list or an array of numbers for single line. For plotting more data sets, input data should be in the form of list of lists as shown below:
 
     .. highlight:: python
     .. code-block:: python


### PR DESCRIPTION
I fixed this because it was preventing the turning off of the floating point numbers' alignment in tables.